### PR TITLE
Adds rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,32 @@
+AllCops:
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+    - '**/*.gemspec'
+  Exclude:
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+    - 'bin/**/*'
+    - 'vendor/**/*'
+
+Metrics/LineLength:
+  Enabled: false
+
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/RegexpLiteral:
+  MaxSlashes: 0

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,6 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+task default: :rubocop

--- a/bitreserve.gemspec
+++ b/bitreserve.gemspec
@@ -4,19 +4,20 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'bitreserve/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "bitreserve"
+  spec.name          = 'bitreserve'
   spec.version       = Bitreserve::VERSION
-  spec.authors       = ["Group Buddies"]
-  spec.email         = ["zamith@groupbuddies.com", "mpalhas@groupbuddies.com"]
-  spec.summary       = %q{A wrapper for the bitreserve API}
-  spec.homepage      = "https://github.com/groupbuddies/bitreserve"
-  spec.license       = "MIT"
+  spec.authors       = ['Group Buddies']
+  spec.email         = ['zamith@groupbuddies.com', 'mpalhas@groupbuddies.com']
+  spec.summary       = 'A wrapper for the bitreserve API'
+  spec.homepage      = 'https://github.com/groupbuddies/bitreserve'
+  spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split('\x0')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rubocop', '0.28.0'
 end

--- a/lib/bitreserve.rb
+++ b/lib/bitreserve.rb
@@ -1,4 +1,4 @@
-require "bitreserve/version"
+require 'bitreserve/version'
 
 module Bitreserve
   # Your code goes here...

--- a/lib/bitreserve/version.rb
+++ b/lib/bitreserve/version.rb
@@ -1,3 +1,3 @@
 module Bitreserve
-  VERSION = "0.0.2"
+  VERSION = '0.0.2'
 end


### PR DESCRIPTION
- Rubocop is now the default rake task (there is no test suite yet)
- Fixes all rubocop warnings based on our usual rubocop defaults (only
  double-quote warnings were happening)
