### PR TITLE
[Cards] Support all endpoints for cards

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,5 +27,8 @@ Style/DotPosition:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
 Style/RegexpLiteral:
   MaxSlashes: 0

--- a/lib/bitreserve.rb
+++ b/lib/bitreserve.rb
@@ -20,6 +20,7 @@ module Bitreserve
 end
 
 require 'bitreserve/request'
+require 'bitreserve/request_data'
 require 'bitreserve/entities/base_entity'
 require 'bitreserve/entities/ticker'
 require 'bitreserve/entities/card'

--- a/lib/bitreserve/api/card.rb
+++ b/lib/bitreserve/api/card.rb
@@ -2,10 +2,33 @@ module Bitreserve
   module API
     module Card
       def all_cards
-        Request.perform_with_objects(:get,
+        Request.perform_with_objects(:get, cards_request_data)
+      end
+
+      def find_card(id: nil)
+        Request.perform_with_object(:get, card_request_data(id))
+      end
+
+      def create_card(label: nil, currency: nil)
+        Request.perform_with_object(:post, cards_request_data(label: label, currency: currency))
+      end
+
+      private
+
+      def cards_request_data(payload = nil)
+        Bitreserve::RequestData.new(
           Bitreserve::Endpoints::CARD,
           Bitreserve::Entities::Card,
-          self
+          authorization_header,
+          payload
+        )
+      end
+
+      def card_request_data(id)
+        Bitreserve::RequestData.new(
+          Bitreserve::Endpoints::CARD + "/#{id}",
+          Bitreserve::Entities::Card,
+          authorization_header
         )
       end
     end

--- a/lib/bitreserve/api/ticker.rb
+++ b/lib/bitreserve/api/ticker.rb
@@ -2,19 +2,21 @@ module Bitreserve
   module API
     module Ticker
       def all_tickers
-        Request.perform_with_objects(:get,
+        request_data = Bitreserve::RequestData.new(
           Bitreserve::Endpoints::TICKER,
           Bitreserve::Entities::Ticker,
-          self
+          authorization_header
         )
+        Request.perform_with_objects(:get, request_data)
       end
 
       def find_ticker(currency: nil)
-        Request.perform_with_objects(:get,
+        request_data = Bitreserve::RequestData.new(
           Bitreserve::Endpoints::TICKER + "/#{currency}",
           Bitreserve::Entities::Ticker,
-          self
+          authorization_header
         )
+        Request.perform_with_objects(:get, request_data)
       end
     end
   end

--- a/lib/bitreserve/client.rb
+++ b/lib/bitreserve/client.rb
@@ -12,5 +12,11 @@ module Bitreserve
     def bearer_token?
       !bearer_token.nil?
     end
+
+    def authorization_header
+      return {} unless bearer_token?
+
+      { 'Authorization' => "Bearer #{bearer_token}" }
+    end
   end
 end

--- a/lib/bitreserve/request.rb
+++ b/lib/bitreserve/request.rb
@@ -3,21 +3,21 @@ module Bitreserve
     include ::HTTParty
     base_uri "#{Bitreserve.api_base}/v#{Bitreserve.api_version}"
 
-    def self.perform_with_objects(http_method, path, klass, client)
-      new(path, client).public_send(http_method).map do |element|
-        klass.new(element)
+    def self.perform_with_objects(http_method, request_data)
+      new(request_data).public_send(http_method).map do |element|
+        request_data.entity.new(element)
       end
     end
 
-    def self.perform_with_object(http_method, path, klass, client)
-      response = new(path, client).public_send(http_method)
-      klass.new(response)
+    def self.perform_with_object(http_method, request_data)
+      response = new(request_data).public_send(http_method)
+      request_data.entity.new(response)
     end
 
-    def initialize(path, client)
-      @path = path
-      @client = client
-      add_headers
+    def initialize(request_data)
+      @path = request_data.endpoint
+      @data = request_data.payload
+      Request.headers request_data.headers
     end
 
     def get
@@ -27,27 +27,17 @@ module Bitreserve
     end
 
     def post
-      response = Request.post(path)
+      response = Request.post(path, body: data)
       log_request_info(:post, response)
       response.parsed_response
     end
 
     private
 
-    attr_reader :path, :client
-
-    def add_headers
-      return unless client.bearer_token?
-
-      Request.headers 'Authorization' => "Bearer #{client.bearer_token}"
-    end
+    attr_reader :path, :data, :client
 
     def log_request_info(http_method, response)
-      Bitreserve.logger.info "[Bitreserve] [#{current_time}] #{http_method.to_s.upcase} #{Request.base_uri}#{path} #{Request.headers} #{response.code}"
-    end
-
-    def current_time
-      Time.now.utc.strftime('%d/%b/%Y %H:%M:%S %Z')
+      Bitreserve.logger.info "[Bitreserve] #{http_method.to_s.upcase} #{Request.base_uri}#{path} #{Request.headers} #{response.code}"
     end
   end
 end

--- a/lib/bitreserve/request_data.rb
+++ b/lib/bitreserve/request_data.rb
@@ -1,0 +1,7 @@
+module Bitreserve
+  class RequestData < Struct.new(:endpoint, :entity, :headers, :payload)
+    def initialize(endpoint, entity, headers = {}, payload = nil)
+      super
+    end
+  end
+end

--- a/spec/api/card_spec.rb
+++ b/spec/api/card_spec.rb
@@ -7,12 +7,39 @@ module Bitreserve
 
       context '#all_cards' do
         it 'gets all the cards' do
+          request_data = Bitreserve::RequestData.new(Endpoints::CARD, Bitreserve::Entities::Card, client.authorization_header)
           allow(Request).to receive(:perform_with_objects)
 
           client.all_cards
 
           expect(Request).to have_received(:perform_with_objects).
-            with(:get, Endpoints::CARD, Bitreserve::Entities::Card, client)
+            with(:get, request_data)
+        end
+      end
+
+      context '#find_card' do
+        it 'gets a specific card' do
+          id = '1234'
+          request_data = Bitreserve::RequestData.new(Endpoints::CARD + "/#{id}", Bitreserve::Entities::Card, client.authorization_header)
+          allow(Request).to receive(:perform_with_object)
+
+          client.find_card(id: id)
+
+          expect(Request).to have_received(:perform_with_object).
+            with(:get, request_data)
+        end
+      end
+
+      context '#create_card' do
+        it 'creates a card' do
+          data = { label: 'New card', currency: 'EUR' }
+          request_data = Bitreserve::RequestData.new(Endpoints::CARD, Bitreserve::Entities::Card, client.authorization_header, data)
+          allow(Request).to receive(:perform_with_object)
+
+          client.create_card(data)
+
+          expect(Request).to have_received(:perform_with_object).
+            with(:post, request_data)
         end
       end
     end

--- a/spec/api/ticker_spec.rb
+++ b/spec/api/ticker_spec.rb
@@ -7,24 +7,26 @@ module Bitreserve
 
       context '#all_tickers' do
         it 'gets all the tickers' do
+          request_data = Bitreserve::RequestData.new(Endpoints::TICKER, Bitreserve::Entities::Ticker, client.authorization_header)
           allow(Request).to receive(:perform_with_objects)
 
           client.all_tickers
 
           expect(Request).to have_received(:perform_with_objects).
-            with(:get, Endpoints::TICKER, Bitreserve::Entities::Ticker, client)
+            with(:get, request_data)
         end
       end
 
       context '#find_ticker' do
         it 'gets a specific ticker' do
-          allow(Request).to receive(:perform_with_objects)
           currency = 'USD'
+          request_data = Bitreserve::RequestData.new(Endpoints::TICKER + "/#{currency}", Bitreserve::Entities::Ticker, client.authorization_header)
+          allow(Request).to receive(:perform_with_objects)
 
           client.find_ticker(currency: currency)
 
           expect(Request).to have_received(:perform_with_objects).
-            with(:get, Endpoints::TICKER + "/#{currency}", Bitreserve::Entities::Ticker, client)
+            with(:get, request_data)
         end
       end
     end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,15 +1,16 @@
 require 'spec_helper'
 
 module Bitreserve
-  describe Request do
+  shared_examples 'perform request method' do |method_name|
     let(:object_class) { double('ObjectClass', new: nil) }
     let(:request) { spy('request') }
+    let(:client) { Bitreserve::Client.new }
 
-    context '.perform_with_object' do
+    context ".#{method_name}" do
       it 'makes the correct call for a GET' do
         allow(Request).to receive(:new).and_return(request)
 
-        Request.perform_with_object(:get, anything, object_class, anything)
+        Request.public_send(method_name, :get, request_data)
 
         expect(request).to have_received(:get)
       end
@@ -17,22 +18,41 @@ module Bitreserve
       it 'makes the correct call for a POST' do
         allow(Request).to receive(:new).and_return(request)
 
-        Request.perform_with_object(:post, anything, object_class, anything)
+        Request.public_send(method_name, :post, request_data)
 
         expect(request).to have_received(:post)
       end
 
-      it 'makes the actual call' do
+      it 'makes the actual GET call' do
         url = '/some-url'
-        client = instance_double('Bitreserve::Client')
-        stub_request(:get, Request.base_uri + url)
+        WebMockHelpers.bitreserve_stub_request(:get, url)
         allow(Request).to receive(:get).and_call_original
-        allow(client).to receive(:bearer_token?)
 
-        Request.perform_with_object(:get, url, object_class, client)
+        Request.public_send(method_name, :get, request_data(url, client))
 
         expect(Request).to have_received(:get).with(url)
       end
+
+      it 'makes the actual POST call' do
+        url = '/some-url'
+        data = { key: 'value' }
+        WebMockHelpers.bitreserve_stub_request(:post, url)
+        allow(Request).to receive(:post).and_call_original
+
+        Request.public_send(method_name, :post, request_data(url, client, data))
+
+        expect(Request).to have_received(:post).with(url, body: data)
+      end
     end
+
+    def request_data(url = anything, client = nil, payload = nil)
+      client ||= double('Client', authorization_header: {})
+      Bitreserve::RequestData.new(url, object_class, client.authorization_header, payload)
+    end
+  end
+
+  describe Request do
+    include_examples 'perform request method', :perform_with_object
+    include_examples 'perform request method', :perform_with_objects
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ end
 
 require 'bitreserve'
 require 'climate_control'
+require 'pry'
 
 Dir[File.join(Bitreserve::ROOT_PATH, '..', 'spec/support/**/*.rb')].each { |f| require f }
 

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,3 +1,10 @@
 require 'webmock/rspec'
 
 WebMock.disable_net_connect!(allow: 'codeclimate.com')
+
+module WebMockHelpers
+  def self.bitreserve_stub_request(method, url, response = [])
+    WebMock::API.stub_request(method, Bitreserve::Request.base_uri + url).
+      to_return(body: response.to_json, headers: { 'Content-Type' =>  'application/json' })
+  end
+end


### PR DESCRIPTION
Creates a RequestData structure that encapsulates the request endpoint,
the entity to use on the response and the client that's making the
request.

Closes #5.
