### PR TITLE
Cleanup constant naming

### DIFF
--- a/lib/bitreserve/api.rb
+++ b/lib/bitreserve/api.rb
@@ -4,7 +4,7 @@ require 'bitreserve/api/card'
 
 module Bitreserve
   module API
-    include Bitreserve::API::Ticker
-    include Bitreserve::API::Card
+    include API::Ticker
+    include API::Card
   end
 end

--- a/lib/bitreserve/api/card.rb
+++ b/lib/bitreserve/api/card.rb
@@ -16,18 +16,18 @@ module Bitreserve
       private
 
       def cards_request_data(payload = nil)
-        Bitreserve::RequestData.new(
-          Bitreserve::Endpoints::CARD,
-          Bitreserve::Entities::Card,
+        RequestData.new(
+          Endpoints::CARD,
+          Entities::Card,
           authorization_header,
           payload
         )
       end
 
       def card_request_data(id)
-        Bitreserve::RequestData.new(
-          Bitreserve::Endpoints::CARD + "/#{id}",
-          Bitreserve::Entities::Card,
+        RequestData.new(
+          Endpoints::CARD + "/#{id}",
+          Entities::Card,
           authorization_header
         )
       end

--- a/lib/bitreserve/api/ticker.rb
+++ b/lib/bitreserve/api/ticker.rb
@@ -2,18 +2,18 @@ module Bitreserve
   module API
     module Ticker
       def all_tickers
-        request_data = Bitreserve::RequestData.new(
-          Bitreserve::Endpoints::TICKER,
-          Bitreserve::Entities::Ticker,
+        request_data = RequestData.new(
+          Endpoints::TICKER,
+          Entities::Ticker,
           authorization_header
         )
         Request.perform_with_objects(:get, request_data)
       end
 
       def find_ticker(currency: nil)
-        request_data = Bitreserve::RequestData.new(
-          Bitreserve::Endpoints::TICKER + "/#{currency}",
-          Bitreserve::Entities::Ticker,
+        request_data = RequestData.new(
+          Endpoints::TICKER + "/#{currency}",
+          Entities::Ticker,
           authorization_header
         )
         Request.perform_with_objects(:get, request_data)

--- a/lib/bitreserve/client.rb
+++ b/lib/bitreserve/client.rb
@@ -2,7 +2,7 @@ require 'bitreserve/api'
 
 module Bitreserve
   class Client
-    include Bitreserve::API
+    include API
     attr_reader :bearer_token
 
     def initialize(token: ENV['BITRESERVE_AUTH_TOKEN'])


### PR DESCRIPTION
I don't think we need to be calling `Bitreserve::` every time It's just visual
noise
