### PR TITLE
Fixes authentication requests conflicts

### DIFF
--- a/lib/bitreserve/api/auth_token.rb
+++ b/lib/bitreserve/api/auth_token.rb
@@ -9,7 +9,7 @@ module Bitreserve
           nil,
           username: username, password: password
         )
-        Request.perform_with_object(:post, request_data)
+        AuthRequest.perform_with_object(:post, request_data)
       end
     end
   end

--- a/spec/auth_request_spec.rb
+++ b/spec/auth_request_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+module Bitreserve
+  shared_examples 'perform auth request method' do |method_name|
+    let(:object_class) { double('ObjectClass', new: nil, from_collection: nil) }
+    let(:request) { spy('request') }
+    let(:client) { Bitreserve::Client.new }
+
+    context ".#{method_name}" do
+      it 'makes a call with basic auth' do
+        url = '/some-url'
+        auth = { username: 'user', password: 'pass' }
+        WebMockHelpers.bitreserve_stub_request_with_auth(:get, url, [], auth)
+        allow(AuthRequest).to receive(:get).and_call_original
+
+        AuthRequest.public_send(method_name, :get, request_data(url, client, nil, auth))
+
+        expect(AuthRequest).to have_received(:get).with(url, basic_auth: auth, headers: client.authorization_header)
+      end
+    end
+
+    def request_data(url = anything, client = nil, payload = nil, auth = nil)
+      client ||= double('Client', authorization_header: {})
+      RequestData.new(url, object_class, client.authorization_header, payload, auth)
+    end
+  end
+
+  describe AuthRequest do
+    include_examples 'perform auth request method', :perform_with_object
+    include_examples 'perform auth request method', :perform_with_objects
+  end
+end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -30,7 +30,7 @@ module Bitreserve
 
         Request.public_send(method_name, :get, request_data(url, client))
 
-        expect(Request).to have_received(:get).with(url, {})
+        expect(Request).to have_received(:get).with(url, headers: client.authorization_header)
       end
 
       it 'makes the actual POST call' do
@@ -41,18 +41,7 @@ module Bitreserve
 
         Request.public_send(method_name, :post, request_data(url, client, data))
 
-        expect(Request).to have_received(:post).with(url, body: data)
-      end
-
-      it 'makes a call with basic auth' do
-        url = '/some-url'
-        auth = { username: 'user', password: 'pass' }
-        WebMockHelpers.bitreserve_stub_request_with_auth(:get, url, [], auth)
-        allow(Request).to receive(:get).and_call_original
-
-        Request.public_send(method_name, :get, request_data(url, client, nil, auth))
-
-        expect(Request).to have_received(:get).with(url, basic_auth: auth)
+        expect(Request).to have_received(:post).with(url, body: data, headers: client.authorization_header)
       end
     end
 

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -18,7 +18,7 @@ module WebMockHelpers
   private
 
   def self.generate_auth_url(url, auth)
-    uri = URI.parse(Bitreserve::Request.base_uri)
+    uri = URI.parse(Bitreserve::AuthRequest.base_uri)
     uri.scheme + '://' + auth[:username] + ':' + auth[:password] + '@' + uri.host + url
   end
 end


### PR DESCRIPTION
Bitreserve::Request currently introduces a global state, storing the base_uri and default headers
Authentication requests were interfering with this state, making all further requests use the wrong uri

This creates an extra class, AuthRequest, which should be used for requests targeting the authentication base_uri.
