### PR TITLE
Create and commit a transaction in a single request

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ client.commit_transaction(card_id: 'a6d35fcd-xxxx-9c9d1dda6d57', transaction_id:
 'd51b4e4e-9827-40fb-8763-e0ea2880085b')
 ```
 
+**Create and commit a transaction in a single request:**
+
+```ruby
+client.create_and_commit_transaction(card_id: 'a6d35fcd-xxxx-9c9d1dda6d57', currency:
+'BTC', amount: 0.1, destination: 'foo@bar.com')
+```
+
 **Cancel a transaction:**
 
 ```ruby

--- a/lib/uphold/api/endpoints.rb
+++ b/lib/uphold/api/endpoints.rb
@@ -3,6 +3,7 @@ module Uphold
     AUTH = '/me/tokens'
     CARD = '/me/cards'
     CARD_PRIVATE_TRANSACTIONS = CARD + '/:card/transactions'
+    CREATE_AND_COMMIT_TRANSACTION = CARD_PRIVATE_TRANSACTIONS + '?commit=true'
     COMMIT_TRANSACTION = CARD_PRIVATE_TRANSACTIONS + '/:id/commit'
     CANCEL_TRANSACTION = CARD_PRIVATE_TRANSACTIONS + '/:id/cancel'
     RESEND_TRANSACTION = CARD_PRIVATE_TRANSACTIONS + '/:id/resend'

--- a/lib/uphold/api/private_transaction.rb
+++ b/lib/uphold/api/private_transaction.rb
@@ -16,6 +16,16 @@ module Uphold
         Request.perform_with_object(:post, request_data)
       end
 
+      def create_and_commit_transaction(card_id: nil, currency: nil, amount: 0, destination: nil)
+        request_data = RequestData.new(
+          Endpoints.with_placeholders(Endpoints::CREATE_AND_COMMIT_TRANSACTION, ':card' => card_id),
+          Entities::Transaction,
+          authorization_header,
+          card_id: card_id, denomination: { currency: currency, amount: amount }, destination: destination
+        )
+        Request.perform_with_object(:post, request_data)
+      end
+
       def cancel_transaction(card_id: nil, transaction_id: nil)
         request_data = transaction_request_data(Endpoints::CANCEL_TRANSACTION, card_id, transaction_id)
         Request.perform_with_object(:post, request_data)

--- a/lib/uphold/version.rb
+++ b/lib/uphold/version.rb
@@ -1,3 +1,3 @@
 module Uphold
-  VERSION = '1.1.1'
+  VERSION = '1.2.0'
 end

--- a/spec/unit/api/private_transaction_spec.rb
+++ b/spec/unit/api/private_transaction_spec.rb
@@ -41,6 +41,24 @@ module Uphold
         end
       end
 
+      context '#create_and_commit_transaction' do
+        it 'creates a transaction for a specific card' do
+          card_id = '1234'
+          request_data = RequestData.new(
+            Endpoints.with_placeholders(Endpoints::CREATE_AND_COMMIT_TRANSACTION, ':card' => card_id),
+            Entities::Transaction,
+            client.authorization_header,
+            card_id: card_id, denomination: { currency: 'USD', amount: 10 }, destination: 'foo@bar.com'
+          )
+          allow(Request).to receive(:perform_with_object)
+
+          client.create_and_commit_transaction(card_id: card_id, currency: 'USD', amount: 10, destination: 'foo@bar.com')
+
+          expect(Request).to have_received(:perform_with_object).
+            with(:post, request_data)
+        end
+      end
+
       context '#cancel_transaction' do
         it 'cancels a transaction for a specific card' do
           card_id = '1234'


### PR DESCRIPTION
Uphold now supports creating & committing a transaction in a single request, by appending `?commit=true' to the transaction creation URL

This PR implements that functionality as new method, `create_and_commit_transaction`

The choice for the method name is perhaps not the best. I would rather go with an approach such as:
- prepare_transaction: equivalent to our current create_transaction
- commit_transaction: stays the same
- create_transaction: implements the functionality added in this PR

But the approach above would require us to rename an existing method, and have a new feature take its place. This wouldn't be a change that we could make right at once (unless we move to 2.0)
