### PR TITLE
Dropping Card#addresses attribute

### DIFF
--- a/lib/uphold/entities/base_entity.rb
+++ b/lib/uphold/entities/base_entity.rb
@@ -5,7 +5,7 @@ module Uphold
 
       def self.from_collection(entities, content_range)
         total_size = (content_range && content_range.split('/')[1]) || entities.size
-        items = entities.map { |entity| new(entity) }
+        items = entities.map { |entity| new(entity.to_h) }
 
         PaginatedCollection.new(items, total_size)
       end

--- a/lib/uphold/entities/card.rb
+++ b/lib/uphold/entities/card.rb
@@ -3,7 +3,6 @@ module Uphold
     class Card < BaseEntity
       attribute :id
       attribute :address
-      attribute :addresses
       attribute :label
       attribute :currency
       attribute :balance

--- a/lib/uphold/request.rb
+++ b/lib/uphold/request.rb
@@ -13,7 +13,7 @@ module Uphold
       response = new(request_data).public_send(http_method)
 
       with_valid_response(response) do
-        request_data.entity.from_collection(response.parsed_response, response.headers['content-range'])
+        request_data.entity.from_collection(response.parsed_response.to_h, response.headers['content-range'])
       end
     end
 

--- a/lib/uphold/request.rb
+++ b/lib/uphold/request.rb
@@ -13,7 +13,7 @@ module Uphold
       response = new(request_data).public_send(http_method)
 
       with_valid_response(response) do
-        request_data.entity.from_collection(response.parsed_response.to_h, response.headers['content-range'])
+        request_data.entity.from_collection(response.parsed_response, response.headers['content-range'])
       end
     end
 

--- a/lib/uphold/version.rb
+++ b/lib/uphold/version.rb
@@ -1,3 +1,3 @@
 module Uphold
-  VERSION = '1.2.2'
+  VERSION = '1.2.3'
 end

--- a/lib/uphold/version.rb
+++ b/lib/uphold/version.rb
@@ -1,3 +1,3 @@
 module Uphold
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end

--- a/spec/fixtures/vcr_cassettes/me/card.yml
+++ b/spec/fixtures/vcr_cassettes/me/card.yml
@@ -55,7 +55,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":"d9cfb5ec-27b3-427a-8ee6-084a7c6b5d2a","address":{"bitcoin":"1JbnsnxESsu1bV3DV4DPCSNp15JQ6yCPgC"},"label":"USD
-        card","currency":"USD","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":2,"addresses":[{"id":"1JbnsnxESsu1bV3DV4DPCSNp15JQ6yCPgC","network":"bitcoin"}]}'
+        card","currency":"USD","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":2}'
     http_version: 
   recorded_at: Tue, 27 Jan 2015 14:24:24 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/me/cards.yml
+++ b/spec/fixtures/vcr_cassettes/me/cards.yml
@@ -55,13 +55,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"id":"2daa59e8-89c5-4cbe-99fc-f66435024bcf","address":{"bitcoin":"1LbHhVFjLeC3hVhW4FXrwu7MNUCkoGTwA5"},"label":"XAU
-        card","currency":"XAU","balance":"0.001","available":"0.001","lastTransactionAt":"2014-12-02T00:29:45.507Z","position":7,"addresses":[{"id":"1LbHhVFjLeC3hVhW4FXrwu7MNUCkoGTwA5","network":"bitcoin"}]},{"id":"8a77ed0e-d89b-4d73-b438-33cd47dcafef","address":{"bitcoin":"1GXDSRdmEyLbgvGa3zBtW1Pftggc8Y8FWK"},"label":"BTC
-        card","currency":"BTC","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":1,"addresses":[{"id":"1GXDSRdmEyLbgvGa3zBtW1Pftggc8Y8FWK","network":"bitcoin"}]},{"id":"d9cfb5ec-27b3-427a-8ee6-084a7c6b5d2a","address":{"bitcoin":"1JbnsnxESsu1bV3DV4DPCSNp15JQ6yCPgC"},"label":"USD
-        card","currency":"USD","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":2,"addresses":[{"id":"1JbnsnxESsu1bV3DV4DPCSNp15JQ6yCPgC","network":"bitcoin"}]},{"id":"7faab8e0-fbb7-4bb4-ad2f-9e0e05eabc35","address":{"bitcoin":"1BsvBJnjXGPC68mPPmcsvUYzidGSXgJd7Q"},"label":"GBP
-        card","currency":"GBP","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":4,"addresses":[{"id":"1BsvBJnjXGPC68mPPmcsvUYzidGSXgJd7Q","network":"bitcoin"}]},{"id":"1f3e8557-5a42-4cf9-a3fd-919b614b87f5","address":{"bitcoin":"19xscksV9K5tG3PQEkKfNWjaxSu8gzX1pi"},"label":"CNY
-        card","currency":"CNY","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":5,"addresses":[{"id":"19xscksV9K5tG3PQEkKfNWjaxSu8gzX1pi","network":"bitcoin"}]},{"id":"353cc6d4-b19f-42ec-a733-bbaf45cb0089","address":{"bitcoin":"192R94xg5acCAYJqXYWve4L6WEaEEMU3RY"},"label":"JPY
-        card","currency":"JPY","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":6,"addresses":[{"id":"192R94xg5acCAYJqXYWve4L6WEaEEMU3RY","network":"bitcoin"}]},{"id":"21a6f110-a684-4627-afda-bf03eca733cf","address":{"bitcoin":"1M8JNAoPxKfQivX8rzo3x1qKX6tf857HGf"},"label":"EUR
-        card","currency":"EUR","balance":"5.85","available":"5.85","lastTransactionAt":"2014-11-21T17:37:04.769Z","position":3,"addresses":[{"id":"1M8JNAoPxKfQivX8rzo3x1qKX6tf857HGf","network":"bitcoin"}]}]'
+        card","currency":"XAU","balance":"0.001","available":"0.001","lastTransactionAt":"2014-12-02T00:29:45.507Z","position":7},{"id":"8a77ed0e-d89b-4d73-b438-33cd47dcafef","address":{"bitcoin":"1GXDSRdmEyLbgvGa3zBtW1Pftggc8Y8FWK"},"label":"BTC
+        card","currency":"BTC","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":1},{"id":"d9cfb5ec-27b3-427a-8ee6-084a7c6b5d2a","address":{"bitcoin":"1JbnsnxESsu1bV3DV4DPCSNp15JQ6yCPgC"},"label":"USD
+        card","currency":"USD","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":2},{"id":"7faab8e0-fbb7-4bb4-ad2f-9e0e05eabc35","address":{"bitcoin":"1BsvBJnjXGPC68mPPmcsvUYzidGSXgJd7Q"},"label":"GBP
+        card","currency":"GBP","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":4},{"id":"1f3e8557-5a42-4cf9-a3fd-919b614b87f5","address":{"bitcoin":"19xscksV9K5tG3PQEkKfNWjaxSu8gzX1pi"},"label":"CNY
+        card","currency":"CNY","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":5},{"id":"353cc6d4-b19f-42ec-a733-bbaf45cb0089","address":{"bitcoin":"192R94xg5acCAYJqXYWve4L6WEaEEMU3RY"},"label":"JPY
+        card","currency":"JPY","balance":"0.00","available":"0.00","lastTransactionAt":null,"position":6},{"id":"21a6f110-a684-4627-afda-bf03eca733cf","address":{"bitcoin":"1M8JNAoPxKfQivX8rzo3x1qKX6tf857HGf"},"label":"EUR
+        card","currency":"EUR","balance":"5.85","available":"5.85","lastTransactionAt":"2014-11-21T17:37:04.769Z","position":3}]'
     http_version: 
   recorded_at: Tue, 27 Jan 2015 14:13:03 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
The Uphold API is dropping this attribute (already done in the sandbox,
should be live soon)
